### PR TITLE
Add support for calling APIs that return xml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -367,7 +367,18 @@ secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
+[[package]]
+name = "xmltodict"
+version = "0.13.0"
+description = "Makes working with XML feel like you are working with JSON"
+optional = false
+python-versions = ">=3.4"
+files = [
+    {file = "xmltodict-0.13.0-py2.py3-none-any.whl", hash = "sha256:aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852"},
+    {file = "xmltodict-0.13.0.tar.gz", hash = "sha256:341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56"},
+]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8c6425b085e3770b1f16ab27d7a59d79d841040dc3125f2be8eece93d6ffd25a"
+content-hash = "848238ed8d774980d2599d6865197ba62b5e05f66073815fe00671bdde3a43be"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ python = "^3.9"
 requests = "^2.28.2"
 spiffworkflow-connector-command = {git = "https://github.com/sartography/spiffworkflow-connector-command.git", rev = "main"}
 # spiffworkflow-connector-command = {develop = true, path = "../spiffworkflow-connector-command"}
+xmltodict = "^0.13.0"
 
 
 

--- a/src/connector_http/commands/get_request_v2.py
+++ b/src/connector_http/commands/get_request_v2.py
@@ -16,7 +16,10 @@ class GetRequestV2(ConnectorCommand, HttpRequestBase):
         basic_auth_password: str | None = None,
         attempts: int | None = None,
     ):
-        HttpRequestBase.__init__(self, url=url, headers=headers, basic_auth_username=basic_auth_username, basic_auth_password=basic_auth_password)
+        HttpRequestBase.__init__(self, url=url,
+                                 headers=headers,
+                                 basic_auth_username=basic_auth_username,
+                                 basic_auth_password=basic_auth_password)
 
         self.params = params or {}
 

--- a/src/connector_http/http_request_base.py
+++ b/src/connector_http/http_request_base.py
@@ -104,13 +104,14 @@ class HttpRequestBase:
 
         if http_response is not None:
             command_response = {"raw_response": http_response.text}
+            content_type = http_response.headers.get("Content-Type", "")
             # this string can include modifiers like UTF-8, which is why it's not using ==
-            if "application/json" in http_response.headers.get("Content-Type", ""):
+            if "application/json" in content_type:
                 try:
                     command_response = json.loads(http_response.text)
                 except Exception as e:
                     error = self._create_error_from_exception(exception=e, http_response=http_response)
-            elif "application/xml" in http_response.headers.get("Content-Type", ""):
+            elif "application/xml" in content_type or "text/xml" in content_type:
                 try:
                     command_response = xmltodict.parse(http_response.text)
                 except Exception as e:
@@ -121,7 +122,7 @@ class HttpRequestBase:
             error = self._create_error(error_code=f"HttpError{status}", http_response=http_response)
 
         return_response: CommandResponseDict = {
-            "body": json.dumps(command_response),
+            "body": command_response,
             "mimetype": mimetype,
             "http_status": status,
         }

--- a/src/connector_http/http_request_base.py
+++ b/src/connector_http/http_request_base.py
@@ -1,9 +1,9 @@
 import json
 import time
-import xmltodict
 from collections.abc import Callable
 
 import requests  # type: ignore
+import xmltodict
 from spiffworkflow_connector_command.command_interface import CommandErrorDict
 from spiffworkflow_connector_command.command_interface import CommandResponseDict
 from spiffworkflow_connector_command.command_interface import ConnectorProxyResponseDict

--- a/src/connector_http/http_request_base.py
+++ b/src/connector_http/http_request_base.py
@@ -1,5 +1,6 @@
 import json
 import time
+import xmltodict
 from collections.abc import Callable
 
 import requests  # type: ignore
@@ -107,6 +108,11 @@ class HttpRequestBase:
             if "application/json" in http_response.headers.get("Content-Type", ""):
                 try:
                     command_response = json.loads(http_response.text)
+                except Exception as e:
+                    error = self._create_error_from_exception(exception=e, http_response=http_response)
+            elif "application/xml" in http_response.headers.get("Content-Type", ""):
+                try:
+                    command_response = xmltodict.parse(http_response.text)
                 except Exception as e:
                     error = self._create_error_from_exception(exception=e, http_response=http_response)
             log("Did parse http_response")

--- a/tests/connector_http/unit/test_delete_request_v2.py
+++ b/tests/connector_http/unit/test_delete_request_v2.py
@@ -16,7 +16,7 @@ class TestDeleteRequestV2:
             response = request.execute(None, {})
             assert mock_request.call_count == 1
 
-        assert response["command_response"]["body"] == json.dumps({"raw_response": return_html})
+        assert response["command_response"]["body"] == {"raw_response": return_html}
         assert response["command_response"]["http_status"] == 200
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is None
@@ -35,7 +35,7 @@ class TestDeleteRequestV2:
             assert mock_request.call_count == 1
 
         assert response is not None
-        assert response["command_response"]["body"] == json.dumps(return_json)
+        assert response["command_response"]["body"] == return_json
         assert response["command_response"]["http_status"] == 200
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is None
@@ -53,7 +53,7 @@ class TestDeleteRequestV2:
             assert mock_request.call_count == 1
 
         assert response is not None
-        assert response["command_response"]["body"] == json.dumps(return_json)
+        assert response["command_response"]["body"] == return_json
         assert response["command_response"]["http_status"] == 500
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is not None

--- a/tests/connector_http/unit/test_get_request_v2.py
+++ b/tests/connector_http/unit/test_get_request_v2.py
@@ -41,6 +41,24 @@ class TestGetRequestV2:
         assert response["spiff__logs"] is not None
         assert len(response["spiff__logs"]) > 0
 
+    def test_get_xml_from_url(self) -> None:
+        request = GetRequestV2(url="http://example.com")
+        return_xml = "<hey>we_return</hey>"
+        with patch("requests.get") as mock_request:
+            mock_request.return_value.status_code = 200
+            mock_request.return_value.ok = True
+            mock_request.return_value.headers = {"Content-Type": "application/xml"}
+            mock_request.return_value.text = return_xml
+            response = request.execute(None, {})
+
+        assert response is not None
+        assert response["command_response"]["body"] == json.dumps({"hey": "we_return"})
+        assert response["command_response"]["http_status"] == 200
+        assert response["command_response"]["mimetype"] == "application/json"
+        assert response["error"] is None
+        assert response["spiff__logs"] is not None
+        assert len(response["spiff__logs"]) > 0
+
     def test_get_can_handle_500(self, sleepless: Any) -> None:
         request = GetRequestV2(url="http://example.com", attempts=3)
         return_json = {"error": "we_did_error"}

--- a/tests/connector_http/unit/test_get_request_v2.py
+++ b/tests/connector_http/unit/test_get_request_v2.py
@@ -16,7 +16,7 @@ class TestGetRequestV2:
             response = request.execute(None, {})
 
         assert response is not None
-        assert response["command_response"]["body"] == json.dumps({"raw_response": return_html})
+        assert response["command_response"]["body"] == {"raw_response": return_html}
         assert response["command_response"]["http_status"] == 200
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is None
@@ -34,14 +34,14 @@ class TestGetRequestV2:
             response = request.execute(None, {})
 
         assert response is not None
-        assert response["command_response"]["body"] == json.dumps(return_json)
+        assert response["command_response"]["body"] == return_json
         assert response["command_response"]["http_status"] == 200
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is None
         assert response["spiff__logs"] is not None
         assert len(response["spiff__logs"]) > 0
 
-    def test_get_xml_from_url(self) -> None:
+    def test_get_application_xml_from_url(self) -> None:
         request = GetRequestV2(url="http://example.com")
         return_xml = "<hey>we_return</hey>"
         with patch("requests.get") as mock_request:
@@ -52,7 +52,25 @@ class TestGetRequestV2:
             response = request.execute(None, {})
 
         assert response is not None
-        assert response["command_response"]["body"] == json.dumps({"hey": "we_return"})
+        assert response["command_response"]["body"] == {"hey": "we_return"}
+        assert response["command_response"]["http_status"] == 200
+        assert response["command_response"]["mimetype"] == "application/json"
+        assert response["error"] is None
+        assert response["spiff__logs"] is not None
+        assert len(response["spiff__logs"]) > 0
+
+    def test_get_text_xml_from_url(self) -> None:
+        request = GetRequestV2(url="http://example.com")
+        return_xml = "<hey>we_return</hey>"
+        with patch("requests.get") as mock_request:
+            mock_request.return_value.status_code = 200
+            mock_request.return_value.ok = True
+            mock_request.return_value.headers = {"Content-Type": "text/xml"}
+            mock_request.return_value.text = return_xml
+            response = request.execute(None, {})
+
+        assert response is not None
+        assert response["command_response"]["body"] == {"hey": "we_return"}
         assert response["command_response"]["http_status"] == 200
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is None
@@ -70,7 +88,7 @@ class TestGetRequestV2:
             assert mock_request.call_count == 3
 
         assert response is not None
-        assert response["command_response"]["body"] == json.dumps(return_json)
+        assert response["command_response"]["body"] == return_json
         assert response["command_response"]["http_status"] == 500
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is not None

--- a/tests/connector_http/unit/test_head_request_v2.py
+++ b/tests/connector_http/unit/test_head_request_v2.py
@@ -16,7 +16,7 @@ class TestHeadRequestV2:
             response = request.execute(None, {})
 
         assert response is not None
-        assert response["command_response"]["body"] == json.dumps({"raw_response": return_html})
+        assert response["command_response"]["body"] == {"raw_response": return_html}
         assert response["command_response"]["http_status"] == 200
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is None
@@ -34,7 +34,7 @@ class TestHeadRequestV2:
             response = request.execute(None, {})
 
         assert response is not None
-        assert response["command_response"]["body"] == json.dumps(return_json)
+        assert response["command_response"]["body"] == return_json
         assert response["command_response"]["http_status"] == 200
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is None
@@ -52,7 +52,7 @@ class TestHeadRequestV2:
             assert mock_request.call_count == 3
 
         assert response is not None
-        assert response["command_response"]["body"] == json.dumps(return_json)
+        assert response["command_response"]["body"] == return_json
         assert response["command_response"]["http_status"] == 500
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is not None

--- a/tests/connector_http/unit/test_patch_request_v2.py
+++ b/tests/connector_http/unit/test_patch_request_v2.py
@@ -16,7 +16,7 @@ class TestPatchRequestV2:
             response = request.execute(None, {})
             assert mock_request.call_count == 1
 
-        assert response["command_response"]["body"] == json.dumps({"raw_response": return_html})
+        assert response["command_response"]["body"] == {"raw_response": return_html}
         assert response["command_response"]["http_status"] == 200
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is None
@@ -35,7 +35,7 @@ class TestPatchRequestV2:
             assert mock_request.call_count == 1
 
         assert response is not None
-        assert response["command_response"]["body"] == json.dumps(return_json)
+        assert response["command_response"]["body"] == return_json
         assert response["command_response"]["http_status"] == 200
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is None
@@ -53,7 +53,7 @@ class TestPatchRequestV2:
             assert mock_request.call_count == 1
 
         assert response is not None
-        assert response["command_response"]["body"] == json.dumps(return_json)
+        assert response["command_response"]["body"] == return_json
         assert response["command_response"]["http_status"] == 500
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is not None

--- a/tests/connector_http/unit/test_post_request_v2.py
+++ b/tests/connector_http/unit/test_post_request_v2.py
@@ -16,7 +16,7 @@ class TestPostRequestV2:
             response = request.execute(None, {})
             assert mock_request.call_count == 1
 
-        assert response["command_response"]["body"] == json.dumps({"raw_response": return_html})
+        assert response["command_response"]["body"] == {"raw_response": return_html}
         assert response["command_response"]["http_status"] == 200
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is None
@@ -35,7 +35,7 @@ class TestPostRequestV2:
             assert mock_request.call_count == 1
 
         assert response is not None
-        assert response["command_response"]["body"] == json.dumps(return_json)
+        assert response["command_response"]["body"] == return_json
         assert response["command_response"]["http_status"] == 200
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is None
@@ -53,7 +53,7 @@ class TestPostRequestV2:
             assert mock_request.call_count == 1
 
         assert response is not None
-        assert response["command_response"]["body"] == json.dumps(return_json)
+        assert response["command_response"]["body"] == return_json
         assert response["command_response"]["http_status"] == 500
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is not None

--- a/tests/connector_http/unit/test_put_request_v2.py
+++ b/tests/connector_http/unit/test_put_request_v2.py
@@ -16,7 +16,7 @@ class TestPutRequestV2:
             response = request.execute(None, {})
             assert mock_request.call_count == 1
 
-        assert response["command_response"]["body"] == json.dumps({"raw_response": return_html})
+        assert response["command_response"]["body"] == {"raw_response": return_html}
         assert response["command_response"]["http_status"] == 200
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is None
@@ -35,7 +35,7 @@ class TestPutRequestV2:
             assert mock_request.call_count == 1
 
         assert response is not None
-        assert response["command_response"]["body"] == json.dumps(return_json)
+        assert response["command_response"]["body"] == return_json
         assert response["command_response"]["http_status"] == 200
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is None
@@ -53,7 +53,7 @@ class TestPutRequestV2:
             assert mock_request.call_count == 1
 
         assert response is not None
-        assert response["command_response"]["body"] == json.dumps(return_json)
+        assert response["command_response"]["body"] == return_json
         assert response["command_response"]["http_status"] == 500
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is not None


### PR DESCRIPTION
Work on https://github.com/sartography/spiff-arena/issues/994

Uses `xmltodict` to translate an xml response into a python dictionary when can then be returned as a regular json response. Also stopped dumping the response into the v2 wrapper, since that meant responses in task data were nested json strings in the "body".