### PR TITLE
add-json-content-type-header

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [ "3.10", "3.11" ]
+        python-version: ["3.10", "3.11"]
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/src/connector_http/http_request_base.py
+++ b/src/connector_http/http_request_base.py
@@ -1,6 +1,7 @@
 import json
 import time
 from collections.abc import Callable
+from typing import Any
 
 import requests  # type: ignore
 import xmltodict
@@ -71,7 +72,7 @@ class HttpRequestBase:
 
             try:
                 log(f"Will call {self.url}")
-                arguments = {
+                arguments: dict[str, Any] = {
                     "url": self.url,
                     "headers": self.headers,
                     "auth": auth,
@@ -80,6 +81,8 @@ class HttpRequestBase:
                 if self.params is not None:
                     arguments["params"] = self.params
                 if self.data is not None:
+                    if not arguments["headers"].keys().include("Content-Type", "Content-type"):
+                        arguments["headers"]["Content-Type"] = "application/json"
                     arguments["json"] = self.data
                 http_response = request_function(**arguments)
                 log(f"Did call {self.url}")

--- a/src/connector_http/http_request_base.py
+++ b/src/connector_http/http_request_base.py
@@ -81,7 +81,11 @@ class HttpRequestBase:
                 if self.params is not None:
                     arguments["params"] = self.params
                 if self.data is not None:
-                    if not arguments["headers"].keys().include("Content-Type", "Content-type"):
+                    if (
+                        "Content-Type" not in self.headers
+                        and "Content-type" not in self.headers
+                        and "content-type" not in self.headers
+                    ):
                         arguments["headers"]["Content-Type"] = "application/json"
                     arguments["json"] = self.data
                 http_response = request_function(**arguments)

--- a/tests/connector_http/unit/test_put_request_v2.py
+++ b/tests/connector_http/unit/test_put_request_v2.py
@@ -6,6 +6,14 @@ from connector_http.commands.put_request_v2 import PutRequestV2
 
 
 class TestPutRequestV2:
+    expected_call_args = {
+        "url": "http://example.com",
+        "headers": {"Content-Type": "application/json"},
+        "auth": None,
+        "timeout": 300,
+        "json": {},
+    }
+
     def test_put_html_from_url(self) -> None:
         request = PutRequestV2(url="http://example.com")
         return_html = "<html>Hey</html>"
@@ -15,6 +23,7 @@ class TestPutRequestV2:
             mock_request.return_value.text = return_html
             response = request.execute(None, {})
             assert mock_request.call_count == 1
+            assert mock_request.call_args_list[0].kwargs == self.expected_call_args
 
         assert response["command_response"]["body"] == {"raw_response": return_html}
         assert response["command_response"]["http_status"] == 200
@@ -33,6 +42,7 @@ class TestPutRequestV2:
             mock_request.return_value.text = json.dumps(return_json)
             response = request.execute(None, {})
             assert mock_request.call_count == 1
+            assert mock_request.call_args_list[0].kwargs == self.expected_call_args
 
         assert response is not None
         assert response["command_response"]["body"] == return_json
@@ -51,11 +61,33 @@ class TestPutRequestV2:
             mock_request.return_value.text = json.dumps(return_json)
             response = request.execute(None, {})
             assert mock_request.call_count == 1
+            assert mock_request.call_args_list[0].kwargs == self.expected_call_args
 
         assert response is not None
         assert response["command_response"]["body"] == return_json
         assert response["command_response"]["http_status"] == 500
         assert response["command_response"]["mimetype"] == "application/json"
         assert response["error"] is not None
+        assert response["spiff__logs"] is not None
+        assert len(response["spiff__logs"]) > 0
+
+    def test_put_does_not_change_content_type(self) -> None:
+        request = PutRequestV2(url="http://example.com", headers={"Content-Type": "application/xml"})
+        return_html = "<html>Hey</html>"
+        with patch("requests.put") as mock_request:
+            mock_request.return_value.status_code = 200
+            mock_request.return_value.ok = True
+            mock_request.return_value.text = return_html
+            response = request.execute(None, {})
+            assert mock_request.call_count == 1
+            assert mock_request.call_args_list[0].kwargs == {
+                **self.expected_call_args,
+                **{"headers": {"Content-Type": "application/xml"}},
+            }
+
+        assert response["command_response"]["body"] == {"raw_response": return_html}
+        assert response["command_response"]["http_status"] == 200
+        assert response["command_response"]["mimetype"] == "application/json"
+        assert response["error"] is None
         assert response["spiff__logs"] is not None
         assert len(response["spiff__logs"]) > 0


### PR DESCRIPTION
We only support json content types at the moment so add the header if not present.